### PR TITLE
Make sure there's no exception if collective.leadimage is installed...

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,10 @@ Changelog
 3.3 (unreleased)
 ----------------
 
+- Make sure there's no exception if collective.leadimage is installed and
+  obj.image is set to NamedImage/NamedBlobImage.
+  [href]
+
 - Added BalloonStyle
   [kroman0]
 

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(name='collective.geo.kml',
       extras_require={
           'test': [
               'plone.app.testing',
+              'mock'
           ]
       },
       entry_points="""

--- a/src/collective/geo/kml/browser/kmldocument.py
+++ b/src/collective/geo/kml/browser/kmldocument.py
@@ -273,8 +273,9 @@ class Placemark(Feature):
         if HAS_LEADIMAGE and not image_field:
             image_field = obj.getField(IMAGE_FIELD_NAME)
 
-        if image_field and image_field.get_size(obj):
-            return image_field.tag(obj, scale=scale, css_class=css_class)
+        if image_field and hasattr(image_field, 'get_size'):
+            if image_field.get_size(obj):
+                return image_field.tag(obj, scale=scale, css_class=css_class)
         return None
 
     @property

--- a/src/collective/geo/kml/tests/test_kmldocument.py
+++ b/src/collective/geo/kml/tests/test_kmldocument.py
@@ -1,0 +1,52 @@
+import unittest2 as unittest
+from ..testing import CGEO_KML_INTEGRATION
+
+
+class TestKMLDocument(unittest.TestCase):
+    layer = CGEO_KML_INTEGRATION
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        self.request = self.layer['request']
+
+    def test_lead_image_render(self):
+        from collective.geo.kml.browser import kmldocument
+        from plone.namedfile.file import NamedBlobImage, NamedImage
+        from plone.namedfile.tests.test_blobfile import registerUtilities
+        from mock import Mock
+
+        # get NamedBlobImage/NamedImage to work in this test
+        registerUtilities()
+
+        # so we don't need collective.contentleadimage for the test
+        kmldocument.HAS_LEADIMAGE = True
+
+        # we could use ATImage, but since that is deprecated, we just mock it
+        class ATImage(object):
+            def get_size(self, obj):
+                return 1
+
+            def tag(self, obj, scale, css_class):
+                return '<img>'
+
+        placemark = kmldocument.Placemark(self.portal, self.request)
+        placemark.context.getField = Mock(return_value=ATImage())
+
+        self.assertEqual(placemark.lead_image(), '<img>')
+
+        # now let's try with NamedBlobImage and NamedImage
+        placemark.context.getField = Mock(return_value=NamedImage())
+        self.assertEqual(placemark.lead_image(), None)
+
+        placemark.context.getField = Mock(return_value=NamedBlobImage())
+        self.assertEqual(placemark.lead_image(), None)
+
+        # or anything else really
+        placemark.context.getField = Mock(return_value=object())
+        self.assertEqual(placemark.lead_image(), None)
+
+
+def test_suite():
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(TestKMLDocument))
+    return suite


### PR DESCRIPTION
... and obj.image is set to NamedImage/NamedBlobImage.

Fixes #8.
